### PR TITLE
Update Browserslist database to latest version

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -20,7 +20,7 @@ _No open issues tracked at this time._
 
 ## Changelog
 
-| Date | Issue | Description |
-|------|-------|-------------|
-| 2026-01-02 | #11 | Updated Browserslist database |
-| 2026-01-02 | #10 | Fixed CVE-2025-15284 security vulnerability |
+| Date       | Issue | Description                                 |
+| ---------- | ----- | ------------------------------------------- |
+| 2026-01-02 | #11   | Updated Browserslist database               |
+| 2026-01-02 | #10   | Fixed CVE-2025-15284 security vulnerability |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,26 @@
+# Roadmap
+
+This document tracks the development progress and planned work for the Cuckoo and the Birds project.
+
+## Completed
+
+### Maintenance
+
+- [x] **#11** - Update stale Browserslist database (2026-01-02)
+  - Updated caniuse-lite from 1.0.30001696 to 1.0.30001762
+  - Eliminates build warnings about outdated browser data
+
+- [x] **#10** - Fix CVE-2025-15284: qs DoS vulnerability (2026-01-02)
+  - Fixed high severity security vulnerability in qs package
+  - Updated cypress, react-router, and related dependencies
+
+## Open Issues
+
+_No open issues tracked at this time._
+
+## Changelog
+
+| Date | Issue | Description |
+|------|-------|-------------|
+| 2026-01-02 | #11 | Updated Browserslist database |
+| 2026-01-02 | #10 | Fixed CVE-2025-15284 security vulnerability |

--- a/package-lock.json
+++ b/package-lock.json
@@ -3855,9 +3855,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001696",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001696.tgz",
-      "integrity": "sha512-pDCPkvzfa39ehJtJ+OwGT/2yvT2SbjfHhiIW2LWOAcMQ7BzwxT/XuyUp4OTOd0XFWA6BKw0JalnBHgSi5DGJBQ==",
+      "version": "1.0.30001762",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001762.tgz",
+      "integrity": "sha512-PxZwGNvH7Ak8WX5iXzoK1KPZttBXNPuaOvI2ZYU7NrlM+d9Ov+TUvlLOBNGzVXAntMSMMlJPd+jY6ovrVjSmUw==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## Summary

Updates the Browserslist database (caniuse-lite) to the latest version, eliminating the build warning about outdated browser data.

Closes #11

## Changes

- **caniuse-lite**: 1.0.30001696 → 1.0.30001762
- **ROADMAP.md**: Created to track project progress

## Why This Matters

Browserslist data is used by:
- **Autoprefixer** - to determine which CSS prefixes are needed
- **Babel** - to determine which JavaScript transformations are needed  
- **PostCSS** - for CSS compatibility

Outdated data means the build may include unnecessary polyfills/prefixes for browsers that no longer need them, or miss support for newer browser versions.

## Verification

- Build no longer shows "Browserslist: browsers data is 12 months old" warning
- All 131 tests pass
- No target browser changes (existing browser support unchanged)

## Test plan

- [x] Run `npm run build` - no Browserslist warning
- [x] Run `npm test` - all 131 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a project roadmap documenting completed maintenance tasks and upcoming work; changelog entries included.

* **Bug Fixes**
  * Resolved a dependency DoS security vulnerability.

* **Chores**
  * Updated multiple dependencies (including Browserslist data) to remove build warnings and address security concerns.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->